### PR TITLE
Update README_usbflashing.md

### DIFF
--- a/README_usbflashing.md
+++ b/README_usbflashing.md
@@ -7,5 +7,5 @@ How to flash a ROM using a USB-a to USB-a cable.
 <br> Plug the USB-A to USB-A cable in to the computer but not the box yet
 <br> Then push in and hold the reset button while plugging the usb cable into your android box. If you do not see the reset button, it is probably inside the AV port. Use a non condutive material to press it (toothpick for example).
 <br> It will only work on 1 of your boxes USB ports, so if nothing happens try the other one. If that doesnt help try other ports on your computer, or maybe even another computer, or another cable
-<br> When the box is seen in the burn tool it will start flashing. Connect the power cable.
+<br> When the box is seen in the burn tool it will start flashing. Try connecting the power cable too if the box is not detected (optional).
 <br> After 100% you may click stop. Then close the USB burn tool. Then unplug the box. Congratulations, you have flashed the ROM!


### PR DESCRIPTION
Add plugin power cable as option. Most (if not all) ATVs can run only on USB power during flash.