### PR TITLE
Read all version in a nicely formatted string

### DIFF
--- a/personal_commands/atv-versions.json
+++ b/personal_commands/atv-versions.json
@@ -1,0 +1,10 @@
+{
+    "ATV - Readout ALL Versions":
+    [
+	{
+	    "TYPE": "jobType.PASSTHROUGH",
+            "SYNTAX": "echo \"RGC $(dumpsys package de.grennith.rgc.remotegpscontroller | grep versionName | head -n1 | sed 's/ *versionName=//') | PD $(dumpsys package com.mad.pogodroid | grep versionName | head -n1 | sed 's/ *versionName=//') | PoGo $(dumpsys package com.nianticlabs.pokemongo | grep versionName | head -n1 | sed 's/ *versionName=//') | ROM $(cat /sdcard/madversion 2>/dev/null || echo unknown)\"",
+	    "FIELDNAME": "Versions"
+	}
+    ]
+}


### PR DESCRIPTION
The current set of commands to read out the various software versions is a little complicated and has no fancy output. This command tries to collect all versions at once and to beautify the output in a single readable string.