### PR TITLE
Blink x96 LED to identify device

### DIFF
--- a/personal_commands/blick_led_madatv.json
+++ b/personal_commands/blick_led_madatv.json
@@ -1,0 +1,9 @@
+{
+  "ATV - Blink x96w LED": [
+    {
+      "TYPE": "jobType.PASSTHROUGH",
+      "SYNTAX": "F=/sys/class/leds/led-sys/brightness su -c 'echo 0 > $F && sleep 0.5 && echo 1 > $F && sleep 0.5 && echo 0 > $F && sleep 0.5 && echo 1 > $F && sleep 0.5 && echo 0 > $F && sleep 0.5 && echo 1 > $F && sleep 0.5 && echo 0 > $F && sleep 0.5 && echo 1 > $F'",
+      "WAITTIME": 0
+    }
+  ]
+}


### PR DESCRIPTION
This job blinks the ATV's LED a few times to help identifying a specific physical device.

Tested on x96mini only, feedback for other models welcome.