### PR TITLE
added missing curl option -k to fix connection with LetsEncrypt certs

### DIFF
--- a/update_mad.sh
+++ b/update_mad.sh
@@ -75,7 +75,7 @@ cast_alohomora(){
 #update rgc using the wizard
 pserver=$(grep -v raw "$pdconf"|awk -F'>' '/post_destination/{print $2}'|awk -F'<' '{print $1}')
 origin=$(awk -F'>' '/post_origin/{print $2}' "$pdconf"|awk -F'<' '{print $1}')
-newver="$(curl -s -L $(get_pd_user) -H "origin: $origin" "$pserver/mad_apk/rgc/noarch")"
+newver="$(curl -s -k -L $(get_pd_user) -H "origin: $origin" "$pserver/mad_apk/rgc/noarch")"
 installedver="$(dumpsys package de.grennith.rgc.remotegpscontroller 2>/dev/null|awk -F'=' '/versionName/{print $2}'|head -n1)"
 if checkupdate "$newver" "$installedver" ;then
  echo "updating RGC..."
@@ -93,7 +93,7 @@ cast_imperius(){
 #update pogodroid using the wizard
 pserver=$(grep -v raw "$pdconf"|awk -F'>' '/post_destination/{print $2}'|awk -F'<' '{print $1}')
 origin=$(awk -F'>' '/post_origin/{print $2}' "$pdconf"|awk -F'<' '{print $1}')
-newver="$(curl -s -L $(get_pd_user) -H "origin: $origin" "$pserver/mad_apk/pogodroid/noarch")"
+newver="$(curl -s -k -L $(get_pd_user) -H "origin: $origin" "$pserver/mad_apk/pogodroid/noarch")"
 installedver="$(dumpsys package com.mad.pogodroid|awk -F'=' '/versionName/{print $2}'|head -n1)"
 if checkupdate "$newver" "$installedver" ;then
  echo "updating pogodroid..."
@@ -110,7 +110,7 @@ reboot=1
 update_pokemon(){
 pserver=$(grep -v raw "$pdconf"|awk -F'>' '/post_destination/{print $2}'|awk -F'<' '{print $1}')
 origin=$(awk -F'>' '/post_origin/{print $2}' "$pdconf"|awk -F'<' '{print $1}')
-newver="$(curl -s -L $(get_pd_user) -H "origin: $origin" "$pserver/mad_apk/pogo/armeabi-v7a")"
+newver="$(curl -s -k -L $(get_pd_user) -H "origin: $origin" "$pserver/mad_apk/pogo/armeabi-v7a")"
 installedver="$(dumpsys package com.nianticlabs.pokemongo|awk -F'=' '/versionName/{print $2}')"
 [[ "$newver" == "$installedver" ]] && unset UpdatePoGo && echo "The madmin wizard has version $newver and so do we, doing nothing." && return 0
 [[ "$newver" == "" ]] && unset UpdatePoGo && echo "The madmin wizard has no pogo in its system apks, or your pogodroid is not configured" && return 1


### PR DESCRIPTION
Hi,

i ran into the issue, that my wizard auto update didnt work, after checking curl commands i found the issue, that http**s** endpoint doesn't work with out LE cert:
```
atvX_s905w:/ # curl  -s -L -u x:yy -H "origin: zzz" "http://pd.server/mad_apk/rgc/noarch"
-> 1.10.1
atvX_s905w:/ # curl  -s -L -u x:yy -H "origin: zzz" "https://pd.server/mad_apk/rgc/noarch"
->
atvX_s905w:/ # curl -k -s -L -u x:yy -H "origin: zzz" "https://pd.server/mad_apk/rgc/noarch"
-> 1.10.1
```
All other commands already use the -k option (for insecure connections), so this shouldn't be a big problem.

Thx