### PR TITLE
Create a permament MAC for a95x

### DIFF
--- a/42mad
+++ b/42mad
@@ -1,6 +1,6 @@
 #!/system/bin/sh
 #This is for update_mad version
-uver="3.3"
+uver="3.5"
 #This is for pingreboot version
 pver="2.0"
 #This is for nfs install script
@@ -163,11 +163,11 @@ if ! grep -q "version $uver" /system/bin/update_mad.sh; then
     download https://raw.githubusercontent.com/Map-A-Droid/MAD-ATV/master/update_mad.sh /system/bin/update_mad.sh
     chmod +x /system/bin/update_mad.sh
 fi
-#if ! grep -q "version $pver" /system/bin/pingreboot.sh; then
-#    echo "Downloading pingreboot.sh"
-#    download https://raw.githubusercontent.com/Map-A-Droid/MAD-ATV/master/pingreboot.sh /system/bin/pingreboot.sh
-#    chmod +x /system/bin/pingreboot.sh
-#fi
+if ! grep -q "version $pver" /system/bin/pingreboot.sh; then
+     echo "Downloading pingreboot.sh"
+     download https://raw.githubusercontent.com/Map-A-Droid/MAD-ATV/master/pingreboot.sh /system/bin/pingreboot.sh
+     chmod +x /system/bin/pingreboot.sh
+fi
 #if ! grep -q "version $nver" /system/bin/nfs_install.sh; then
 #    echo "Downloading nfs_install.sh"
 #    download https://raw.githubusercontent.com/Map-A-Droid/MAD-ATV/master/nfs_install.sh /system/bin/nfs_install.sh
@@ -268,7 +268,6 @@ core_installation
 set_android_settings
 set_permissions
 echo "$madver" > /sdcard/madversion
-execute_autoupdates
 set_mac_unify
 wait_for_network
 autoconfigure_mad

--- a/42mad
+++ b/42mad
@@ -184,6 +184,23 @@ echo "Setting android settings for workers"
 ! settings get secure location_providers_allowed|grep -q gps && settings put secure location_providers_allowed +gps
 echo "Successfully set the settings for workers"
 }
+#Not tested yet
+set_mac_unify(){
+echo "Setting Mac in unifykey"
+
+if [[ "$(ifconfig eth0|awk '/HWaddr/{print $5}')" == "00:15:18:01:81:31" ]] ;then
+   newmac=$(xxd -l 6 -p /dev/urandom |sed 's/../&:/g;s/:$//')
+   ifconfig eth0 down
+   until ifconfig eth0 hw ether "$newmac" 2>/dev/null; do
+     newmac=$(xxd -l 6 -p /dev/urandom |sed 's/../&:/g;s/:$//')
+   done
+   echo 1 > /sys/class/unifykeys/lock
+   echo mac > /sys/class/unifykeys/name
+   echo "$newmac" >/sys/class/unifykeys/write
+   cat /sys/class/unifykeys/read
+   echo 0 > /sys/class/unifykeys/lock
+   ifconfig eth0 up
+}
 
 set_mac_address(){
 echo "Setting MAC address (if required)"
@@ -252,7 +269,7 @@ set_android_settings
 set_permissions
 echo "$madver" > /sdcard/madversion
 execute_autoupdates
-set_mac_address
+set_mac_unify
 wait_for_network
 autoconfigure_mad
 execute_apk_autoupdates


### PR DESCRIPTION
This should create a random mac for A95x F1 and compare it to the current one, if its a diffrent mac then store it in unifykey.

This step should be executed only once during inital setup.

After initial setup there is no need to restart eth0 interface any longer as this was causing sometimes issues.

More testers needed!