### PR TITLE
Fix repack_magisk

### DIFF
--- a/42mad
+++ b/42mad
@@ -315,8 +315,9 @@ echo "Network connection detected"
 }
 
 repack_magisk(){
-sleep 60
-if [ $(pm list packages com.topjohnwu.magisk) ]; then
+until [[ $(pm list packages com.topjohnwu.magisk) ]]; do
+sleep 1
+done;
 echo "repacking magisk"
 monkey -p com.topjohnwu.magisk 1
 sleep 30
@@ -328,7 +329,6 @@ input tap 315 552
 sleep 5
 input tap 881 277
 echo "done"
-fi
 }
 
 wait_for_network

--- a/42mad
+++ b/42mad
@@ -189,7 +189,7 @@ echo "Successfully set the settings for workers"
 }
 
 set_android_language() {
-if ! [[ $(getprop persist.sys.locale) == "en-US" ]]; then
+if ! [[ "$(getprop persist.sys.locale)" == "en-US" ]]; then
  setprop persist.sys.locale en-US; setprop ctl.restart zygote
  echo "setting en-US"
 fi
@@ -314,6 +314,7 @@ echo "Network connection detected"
 }
 
 repack_magisk(){
+sleep 60
 if [ $(pm list packages com.topjohnwu.magisk) ]; then
 echo "repacking magisk"
 monkey -p com.topjohnwu.magisk 1

--- a/42mad
+++ b/42mad
@@ -318,7 +318,7 @@ sleep 60
 if [ $(pm list packages com.topjohnwu.magisk) ]; then
 echo "repacking magisk"
 monkey -p com.topjohnwu.magisk 1
-sleep 10
+sleep 30
 input tap 39 42
 sleep 5
 input tap 150 537

--- a/42mad
+++ b/42mad
@@ -185,11 +185,14 @@ echo "Setting android settings for workers"
 ! [[ $(settings get global stay_on_while_plugged_in) == 3 ]] && settings put global stay_on_while_plugged_in 3
 [ "$(/system/bin/appops get de.grennith.rgc.remotegpscontroller android:mock_location)" = "No operations." ] && /system/bin/appops set de.grennith.rgc.remotegpscontroller android:mock_location allow
 ! settings get secure location_providers_allowed|grep -q gps && settings put secure location_providers_allowed +gps
+echo "Successfully set the settings for workers"
+}
+
+set_android_language() {
 if ! [[ $(getprop persist.sys.locale) == "en-US" ]]; then
  setprop persist.sys.locale en-US; setprop ctl.restart zygote
  echo "setting en-US"
 fi
-echo "Successfully set the settings for workers"
 }
 #Not tested yet
 set_mac_unify(){
@@ -332,7 +335,7 @@ core_installation
 set_android_settings
 set_permissions
 echo "$madver" > /sdcard/madversion
-#setup_google_account
+setup_google_account
 execute_autoupdates
 #set_mac_address
 wait_for_network

--- a/42mad
+++ b/42mad
@@ -332,13 +332,13 @@ core_installation
 set_android_settings
 set_permissions
 echo "$madver" > /sdcard/madversion
-repack_magisk
-setup_google_account
+#setup_google_account
 execute_autoupdates
 #set_mac_address
 wait_for_network
 autoconfigure_mad
 execute_apk_autoupdates
+repack_magisk
 mount -o remount,ro /system
 
 # initdebug

--- a/42mad
+++ b/42mad
@@ -94,6 +94,7 @@ if [ ! -f /sbin/magisk ] || ! magisk -c|grep -q "$mver"  ; then
     echo '--update_package=/sdcard/magisk.zip' >> /cache/recovery/command
     cachereboot=1
 elif [ -f /sdcard/madupdating ]; then
+	echo "Uninstall Magisk Manager"
     pm uninstall com.topjohnwu.magisk
     rm /sdcard/madupdating
 fi

--- a/42mad
+++ b/42mad
@@ -318,7 +318,7 @@ sleep 60
 if [ $(pm list packages com.topjohnwu.magisk) ]; then
 echo "repacking magisk"
 monkey -p com.topjohnwu.magisk 1
-sleep 5
+sleep 10
 input tap 39 42
 sleep 5
 input tap 150 537

--- a/42mad
+++ b/42mad
@@ -188,6 +188,7 @@ echo "Setting android settings for workers"
 echo "Successfully set the settings for workers"
 }
 
+#don't add it for execution as long as no one else is having issues with wrong language
 set_android_language() {
 if ! [[ "$(getprop persist.sys.locale)" == "en-US" ]]; then
  setprop persist.sys.locale en-US; setprop ctl.restart zygote


### PR DESCRIPTION
This fix is needed to get repacking magisk working again.

Rootcause: setprop for language was causing a zygote restart during magisk manager apk installation (I moved that to a seperate function)

I adjusted the sleep times and now its working every time

tested and works 5/5 times (image was reflashed every time :D)