### PR TITLE
Run pingreboot in 42mad

### DIFF
--- a/42mad
+++ b/42mad
@@ -270,6 +270,7 @@ fi
 
 ################ start of execution
 sleep 20 # in case mounting /sdcard and usb takes awhile
+[[ -f "/system/bin/pingreboot.sh" ]] && echo "starting pingreboot" && /system/bin/sh /system/bin/pingreboot.sh &
 wait_for_network
 if [[ -f "$pdconf" ]] ;then
     origin="$(awk -F'>' '/post_origin/{print $2}' "$pdconf"|awk -F'<' '{print $1}')"


### PR DESCRIPTION
Currently we're installing pingreboot but there's no way to launch it.

Just doing the same thing we did in 16mad to have it run.