### PR TITLE
pingreboot64 rework

### DIFF
--- a/42mad
+++ b/42mad
@@ -2,7 +2,7 @@
 #This is for update_mad version
 uver="3.5"
 #This is for pingreboot version
-pver="2.0"
+pver="2.1"
 #This is for nfs install script
 nver="1.2"
 # mad rom version
@@ -18,6 +18,10 @@ pdconf="/data/data/com.mad.pogodroid/shared_prefs/com.mad.pogodroid_preferences.
 requires_autoconf=1
 reboot_required=0
 cachereboot=0
+
+lolcat(){
+log -t 42mad "$1"
+}
 
 download(){
 # $1 = url
@@ -138,7 +142,7 @@ fi
 wait_for_network(){
 echo "Waiting for network"
 until ping -c1 8.8.8.8 >/dev/null 2>/dev/null; do
-    "No network detected.  Sleeping 10s"
+    echo "No network detected.  Sleeping 10s"
     sleep 10
 done
 echo "Network connection detected"
@@ -274,8 +278,10 @@ fi
 }
 
 ################ start of execution
+lolcat "starting up, sleep 20"
 sleep 20 # in case mounting /sdcard and usb takes awhile
 wait_for_network
+lolcat "network established, start 42mad execution"
 if [[ -f "$pdconf" ]] ;then
     origin="$(awk -F'>' '/post_origin/{print $2}' "$pdconf"|awk -F'<' '{print $1}')"
     pdserver="$(grep -v raw "$pdconf"|awk -F'>' '/post_destination/{print $2}'|awk -F'<' '{print $1}')"
@@ -385,5 +391,7 @@ if [[ -f /sdcard/reg_session ]] && [[ -f "$pdconf" ]] && [[ -f "$rgcconf" ]] ;th
     reboot
 fi
 execute_autoupdates
+lolcat "start PingReboot"
+/system/bin/sh /system/bin/pingreboot.sh &
 mount -o remount,ro /system
 # initdebug

--- a/pingreboot.sh
+++ b/pingreboot.sh
@@ -1,35 +1,52 @@
 #!/system/bin/sh
-#version 2.0
+#version 2.1
 
-[ -f /sdcard/pingreboot ] || exit
+lolcat(){
+log -t PingReboot $1
+}
 
-log -t ProtoWifi "pingreboot: started"
+CONF_FILE=/sdcard/pingreboot
+lolcat "checking for $CONF_FILE file"
+if [ -f $CONF_FILE ]; then
+  lolcat "$CONF_FILE found"
+else
+  lolcat "$CONF_FILE not existing, not starting PingReboot"
+  exit 1
+fi
+lolcat "starting"
 
 # These values can be overridden by putting them
 # in $CONF_FILE with a custom value.
 # Simply copy & paste lines you want to change.
 #
-PING_HOST=1.1.1.1
+PING_HOST="google.com"
 RUN_EVERY=30
 REENABLE_EVERY=1
 REBOOT_AFTER=10
 
-source /sdcard/pingreboot
+INTERFACE=$(ip route get 8.8.8.8 | sed -nr 's/.*dev ([^\ ]+).*/\1/p')
+lolcat "identified $INTERFACE as the internet connected interface"
+source $CONF_FILE
 
 c=0
+lolcat "now entering the eternal loop"
 while true; do
   if ping -c 1 "$PING_HOST" > /dev/null; then
+    if (( $c > 0 )); then
+      lolcat "network connection re-established!"
+    fi
     c=0
   else
     c=$((c+1))
-    log -t ProtoWifi "pingreboot: network failure, could not ping $PING_HOST"
+    lolcat "network failure, could not ping $PING_HOST (c=$c)"
     if (( $c > $REBOOT_AFTER )); then
        reboot
     elif (( $c % $REENABLE_EVERY == 0 )); then
-      log -t ProtoWifi "pingreboot: re-enabling WiFi"
-      svc wifi disable
+      lolcat "re-enabling $INTERFACE"
+      ifconfig $INTERFACE down
       sleep 4
-      svc wifi enable
+      ifconfig $INTERFACE up
+      lolcat "interface $INTERFACE re-enabled"
     fi
   fi
   sleep $RUN_EVERY


### PR DESCRIPTION
My second swing at bringing pingreboot to 64bit land 😉 

Also adding a forgotten `echo` and three little logcat messages to 42mad to see it's alive and launching pingreboot.

The `ifconfig` way of re-enabling works on my 10+ 64bit x96mini. I tried to make it wifi-compatible by identifying the `$INTERFACE` from the script instead of hard-coding it. I couldn't verify it working on wifi though, lacking devices running on wifi.

I have seen the re-enabling solving connection issues looking at some logcat. After a manually triggered DSL reconnect on my FritzBox, most of the boxes connected to MAD within about 3 seconds of the re-enabling. A couple fell through and rebooted and connected again afterwards.

@krzee - edits by maintainers are enabled, so feel free to remove the lolcat if you don't like it, or change whatever else doesn't fit your taste. 