### PR TITLE
Patch 25

### DIFF
--- a/42mad
+++ b/42mad
@@ -1,12 +1,12 @@
 #!/system/bin/sh
 #This is for update_mad version
-uver="3.8"
+uver="3.9"
 #This is for pingreboot version
 pver="2.0"
 #This is for nfs install script
 nver="1.2"
 # mad rom version
-madver="0.2"
+madver="0.3"
 #magisk version / url
 magisk_ver="20.3"
 msum="959e46971c2eb500b91a053b2f1c1a8c"

--- a/update_mad.sh
+++ b/update_mad.sh
@@ -1,6 +1,6 @@
 #!/system/bin/sh
 # update mad
-# version 3.8
+# version 3.9
 # created by GhostTalker, hijaked by krz
 #
 # adb connect %1:5555
@@ -186,11 +186,13 @@ fi
 update_dhcp(){
 grep -q net.hostname /system/build.prop && unset UpdateDHCP && return 1
 origin="$(awk -F'>' '/post_origin/{print $2}' /data/data/com.mad.pogodroid/shared_prefs/com.mad.pogodroid_preferences.xml|cut -d'<' -f1)"
+mount -o remount,rw /system
 if grep -q 'net.hostname' /system/build.prop ;then
  sed -i -e "s/^net.hostname=.*/net.hostname=${origin}/g" /system/build.prop
 else
  echo "net.hostname=${origin}" >> /system/build.prop
 fi
+mount -o remount,ro /system
 reboot=1
 }
 


### PR DESCRIPTION
update_mad.sh dhcp funcion update.

Purpose: Enable the use of the "-n" flag of update_mad.sh in 64bit MAD roms 
How was this tested: tested on one 64bits Tx9s