### PR TITLE
Add recursive to delete folders

### DIFF
--- a/update_mad.sh
+++ b/update_mad.sh
@@ -1,6 +1,6 @@
 #!/system/bin/sh
 # update mad
-# version 4.0
+# version 4.1
 # created by GhostTalker, hijaked by krz
 #
 # adb connect %1:5555
@@ -146,7 +146,7 @@ case "$(curl -I -s -k -L $(get_pd_user) -H "origin: $origin" "$pserver/mad_apk/p
  *zip*) (cd /sdcard/Download/pogo
        until curl -o /sdcard/Download/pogo/pogo.zip -s -k -L $(get_pd_user) -H "origin: $origin" "$pserver/mad_apk/pogo/$arch/download" && unzip pogo.zip && rm pogo.zip ;do
         echo "Download ZIP PokemonGo"
-        /system/bin/rm -f /sdcard/Download/pogo/*
+        /system/bin/rm -fr /sdcard/Download/pogo/*
         sleep 2
        done
        echo "Install ZIP PokemonGo"
@@ -159,7 +159,7 @@ case "$(curl -I -s -k -L $(get_pd_user) -H "origin: $origin" "$pserver/mad_apk/p
  *vnd.android.package-archive*)
        until curl -o /sdcard/Download/pogo/pogo.apk -s -k -L $(get_pd_user) -H "origin: $origin" "$pserver/mad_apk/pogo/$arch/download" ;do
         echo "Download APK PokemonGo"
-        /system/bin/rm -f /sdcard/Download/pogo/*
+        /system/bin/rm -fr /sdcard/Download/pogo/*
         sleep 2
        done
        echo "Install APK PokemonGo"


### PR DESCRIPTION
Seems like from time to time (or outdate scripts/when people manually upload wrong file?) wizard gives you apk as zip and it's getting unpacked and then everything hangs on unziping because files already exists.
This should fix leftover files from previous broken installs.
Still people need to update this file via job.

https://cdn.discordapp.com/attachments/523602714244939787/826589735584792604/unknown.png
https://cdn.discordapp.com/attachments/523602714244939787/826589798868320266/unknown.png

context: https://discord.com/channels/465247740553592832/523602714244939787/826585196328779826